### PR TITLE
Fix: Download bug for download path not being present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Models/
 .idea/
 .gz
 .pt
+.vscode/

--- a/section2_pytorch_basics/solutions/load.py
+++ b/section2_pytorch_basics/solutions/load.py
@@ -14,6 +14,7 @@ def _download(file_name):
         return
 
     print("Downloading " + file_name + " ... ")
+    os.makedirs(os.path.dirname(file_path), exist_ok=True)
     urllib.request.urlretrieve(url_base + file_name, file_path)
     print("Done")
 


### PR DESCRIPTION
Download function does not check for or create the directories in the download, resulting in `FileNotFoundError` incase the directories are not already present.

Extra: Updated .gitignore to ignore vscode settings.